### PR TITLE
Updates the log handler to take in full log outputs from the compiler server

### DIFF
--- a/odcompile/utils/misc.py
+++ b/odcompile/utils/misc.py
@@ -57,7 +57,9 @@ def getEmbed(logs: json, parsed_output: bool = True) -> Embed:
 
     compile_log = (logs["compiler"][:1200] + "...") if len(logs["compiler"]) > 1200 else logs["compiler"]
 
-    run_log = parseRunOutput(logs["server"], parsed_output=parsed_output)
+    # We need to send a larger sample to the parser to ensure that we properly match our ODC stanza
+    # Sending the full output could result in application hangs if the string is too large
+    run_log = parseRunOutput(logs["server"][:5000], parsed_output=parsed_output)
     run_log = (run_log[:1200] + "...") if len(run_log) > 1200 else run_log
 
     compiler_output = box(escape(compile_log, mass_mentions=True, formatting=True))

--- a/odcompile/utils/misc.py
+++ b/odcompile/utils/misc.py
@@ -55,8 +55,10 @@ def getEmbed(logs: json, parsed_output: bool = True) -> Embed:
         embed = Embed(title="Unable to build image", description=f"{logs['exception']}", color=0xFF0000)
         return embed
 
-    compile_log = logs["compiler"]
+    compile_log = (logs["compiler"][:1200] + "...") if len(logs["compiler"]) > 1200 else logs["compiler"]
+
     run_log = parseRunOutput(logs["server"], parsed_output=parsed_output)
+    run_log = (run_log[:1200] + "...") if len(run_log) > 1200 else run_log
 
     compiler_output = box(escape(compile_log, mass_mentions=True, formatting=True))
     execution_output = box(escape(run_log, mass_mentions=True, formatting=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,15 @@ authors = ["Crossedfall <ping@crossedfall.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "3.11"
-red-discordbot = "^3.5.2"
-httpx = "^0.24.0"
+python = "~3.11"
+red-discordbot = "^3.5"
+httpx = "^0.24"
 
 [tool.poetry.group.dev.dependencies]
-flake8 = "^6.0.0"
-black = "^23.3.0"
-pre-commit = "^3.3.1"
-codespell = "^2.2.4"
+flake8 = "^6.0"
+black = "^23.3"
+pre-commit = "^3.3"
+codespell = "^2.2"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "od-cogs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Cogs for OpenDream"
 authors = ["Crossedfall <ping@crossedfall.io>"]
 readme = "README.md"


### PR DESCRIPTION
Due to recent changes in the OD startup sequence, the cog was unable to match the ODC stanza resulting in bad outputs. 

In order to address this change, I've updated the compiler server's log parser to no longer truncate the log outputs. Instead, it'll send the full logs to the cog and we'll handle additional parsing here as needed. 

----

I've also made some minor tweaks to the pyproject to clean it up a little. 

Partner PR:

- https://github.com/OpenDreamProject/od-compiler-bot/pull/8