### PR TITLE
Pre-commit bump

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+per-file-ignores =
+	tests/*:F401,F811

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,2 @@
 [flake8]
 max-line-length = 120
-per-file-ignores =
-	tests/*:F401,F811

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,33 @@
 repos:
-    - repo: https://github.com/psf/black
-      rev: bf7a162
-      hooks:
-          - id: black
+  - repo: https://github.com/psf/black
+    rev: e877371
+    hooks:
+      - id: black
 
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: f71fa2c
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-yaml
-          - id: check-added-large-files
-          - id: debug-statements
-            language_version: python3
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: f71fa2c
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: debug-statements
+        language_version: python3
 
-    - repo: https://github.com/PyCQA/flake8
-      rev: b9a7794
-      hooks:
-          - id: flake8
-            args:
-                - "--ignore=E501"
-            language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7ef0350
+    hooks:
+      - id: flake8
+        language_version: python3
 
-    - repo: https://github.com/asottile/reorder-python-imports
-      rev: b5d69d1
-      hooks:
-          - id: reorder-python-imports
+  - repo: https://github.com/asottile/reorder-python-imports
+    rev: ba4e0d3
+    hooks:
+      - id: reorder-python-imports
 
-    - repo: https://github.com/codespell-project/codespell
-      rev: ec0f41b
-      hooks:
+  - repo: https://github.com/codespell-project/codespell
+    rev: 355e50e
+    hooks:
       - id: codespell
         additional_dependencies:
-        - tomli
+          - tomli

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you're using multiple functions, or if your code requires indentation, you mu
 	example()
 ```
 #### Arguments
-							
+
 You can pass extra command line arguments to the compiler by adding them before the codeblock.
 
 Adding `--no-parsing` before the codeblock will provide the full execution output instead of a parsed version.

--- a/odcompile/odcompile.py
+++ b/odcompile/odcompile.py
@@ -73,7 +73,7 @@ class ODCompile(commands.Cog):
         Adding `--no-parsing` before the codeblock will provide the full execution output instead of a parsed version.
 
         __Code will always be compiled with the latest version of OpenDream__
-        """
+        """  # noqa: E501
         cleaned_input = splitArgs(args=input)
 
         code = cleanupCode(cleaned_input["code"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ line-length = 120
 count = ""
 skip = ".git,.venv,*.lock,odcompile/utils/regex.py"
 builtin = "clear,rare,code,en-GB_to_en-US"
+ignore-words-list = "od"
 quiet = 3


### PR DESCRIPTION
Bumps the pre-commit tools to their latest versions.

![image](https://github.com/OpenDreamProject/od-cogs/assets/26130695/8da9c2c3-6afd-492f-9fa7-d8a164abb949)

No version bump needed since I didn't change any real code.
