### PR TITLE
Adds a new context option for the compiler cog

### DIFF
--- a/odcompile/__init__.py
+++ b/odcompile/__init__.py
@@ -1,5 +1,13 @@
+from discord import AppCommandType
+
 from .odcompile import ODCompile
+from .utils.appCommands import compileMessage
 
 
 async def setup(bot):
     await bot.add_cog(ODCompile(bot))
+    bot.tree.add_command(compileMessage)
+
+
+async def teardown(bot):
+    bot.tree.remove_command("Compile with OD", type=AppCommandType.message)

--- a/odcompile/utils/appCommands.py
+++ b/odcompile/utils/appCommands.py
@@ -1,0 +1,35 @@
+import discord
+from redbot.core import app_commands
+
+from odcompile.utils.logger import log
+from odcompile.utils.misc import cleanupCode
+from odcompile.utils.misc import splitArgs
+from odcompile.utils.regex import INCLUDE_PATTERN
+from odcompile.utils.relay import processCode
+
+
+@app_commands.guild_only()
+@app_commands.context_menu(name="Compile with OD")
+async def compileMessage(interaction: discord.Interaction, compile_message: discord.Message):
+    cog = interaction.client.get_cog("ODCompile")
+
+    cleaned_input = splitArgs(args=compile_message.content)
+
+    code = cleanupCode(cleaned_input["code"])
+    if code is None:
+        return await interaction.response.send_message("Your code has to be in a code block!")
+    if INCLUDE_PATTERN.search(code) is not None:
+        return await interaction.response.send_message("You can't have any `#include` statements in your code.")
+
+    log.debug(f"Sending code to the listener to be compiled:\n{code}")
+    await interaction.response.defer(thinking=True, ephemeral=False)
+    embed = await processCode(
+        self=cog,
+        code=code,
+        args=cleaned_input["args"],
+        build_config="Release",
+        parsed_output=cleaned_input["parsed"],
+    )
+    return await interaction.followup.send(
+        content=f"Compiled from {compile_message.jump_url}", embed=embed, ephemeral=False
+    )

--- a/odcompile/utils/appCommands.py
+++ b/odcompile/utils/appCommands.py
@@ -13,7 +13,7 @@ from odcompile.utils.relay import processCode
 async def compileMessage(interaction: discord.Interaction, compile_message: discord.Message):
     cog = interaction.client.get_cog("ODCompile")
 
-    cleaned_input = splitArgs(args=compile_message.content)
+    cleaned_input = splitArgs(args=compile_message.content, strict_args=True)
 
     code = cleanupCode(cleaned_input["code"])
     if code is None:

--- a/odcompile/utils/misc.py
+++ b/odcompile/utils/misc.py
@@ -30,7 +30,7 @@ def cleanupCode(content: str) -> str | None:
     return None
 
 
-def splitArgs(args: str, delimiter: str = "`") -> dict:
+def splitArgs(args: str, delimiter: str = "`", strict_args: bool = False) -> dict:
     """
     Take a list of arguments and split them based on the delimiter.
 
@@ -41,7 +41,11 @@ def splitArgs(args: str, delimiter: str = "`") -> dict:
     args = args.split(sep=delimiter, maxsplit=1)
     args_dict["code"] = args[1]
     args_dict["args"] = [arg.replace("\n", "") for arg in args[0].split(" ")]
+    log.error(args_dict["args"])
     args_dict["parsed"] = True
+
+    if strict_args:
+        args_dict["args"] = [arg for arg in args_dict["args"] if arg.startswith("--")]
 
     if "--no-parsing" in args_dict["args"]:
         args_dict["parsed"] = False


### PR DESCRIPTION
Now you can compile code with a few clicks of the mouse instead of having to type out the full command every time. You can even re-compile past runs without having to do anything extra.

Note: In order to use interactive features, you need to run `[p]slash enablecog odcompile` and then `[p]slash sync` to register them onto your bot (where `[p]` is your prefix). Once synced, it can take up to an hour for them to show up on Discord (usually it's faster). 


https://github.com/OpenDreamProject/od-cogs/assets/26130695/565a2047-8bf6-411a-a51b-9426e35f9258

